### PR TITLE
Add Swift Package Manager support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,10 @@ DerivedData
 *.hmap
 *.ipa
 
+# Swift Package Manager
+
+.swiftpm
+
 # Bundler
 .bundle
 

--- a/LifecycleHooks.podspec
+++ b/LifecycleHooks.podspec
@@ -2,7 +2,7 @@
 Pod::Spec.new do |s|
 
   s.name             = "LifecycleHooks"
-  s.version          = "0.6.0"
+  s.version          = "0.6.1"
   s.summary          = "Inject custom code into views and view controllers in response to lifecycle events."
 
   s.description      = <<-DESC

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version:5.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+import PackageDescription
+
+let package = Package(
+    name: "LifecycleHooks",
+    platforms: [
+        .iOS(.v8)
+    ],
+    products: [
+        .library(
+            name: "LifecycleHooks",
+            targets: ["LifecycleHooks"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "LifecycleHooks",
+            dependencies: [],
+            path: "Sources"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -56,8 +56,7 @@ The following parameters allow for further customization of lifecycle hooks:
 
 ### CocoaPods
 
-LifecycleHooks is available through [CocoaPods](http://cocoapods.org). To install
-it, simply add the following line to your Podfile:
+LifecycleHooks is available through [CocoaPods](http://cocoapods.org). To install it, simply add the following line to your Podfile:
 
 ```ruby
 pod 'LifecycleHooks'
@@ -70,6 +69,18 @@ Add the following to your Cartfile:
 ```
 github "johnpatrickmorgan/LifecycleHooks"
 ```
+
+### Swift Package Manager
+
+Adding the following to the `dependencies` array of your `Package.swift`:
+
+```
+dependencies: [
+    .package(url: "https://github.com/johnpatrickmorgan/LifecycleHooks.git", from: "0.6.1")
+]
+```
+
+### 
 
 ## License
 


### PR DESCRIPTION
You will also need to make sure to pull in the tag. SPM will only work from this (tagged in my repo as `0.6.1`) version onwards because it expects to see the `Package.swift` file within the repo for the specific version.